### PR TITLE
Fix CLI script execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { spawn } from 'child_process';
 
 export function run(


### PR DESCRIPTION
## Summary
- allow Node to execute CLI script by adding a shebang line

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ef404e8388322a5f98a4284b34f15